### PR TITLE
Service provider fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/view": "^5.5.0|^6.0",
         "ramsey/uuid": "^3.0",
         "psr/log": "^1.0",
-        "scoutapp/scout-apm-php": "0.2.1"
+        "scoutapp/scout-apm-php": "^0.2.1"
     },
     "require-dev": {
         "doctrine/coding-standard": "^6.0",

--- a/src/Providers/ScoutApmServiceProvider.php
+++ b/src/Providers/ScoutApmServiceProvider.php
@@ -6,11 +6,11 @@ namespace Scoutapm\Laravel\Providers;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Events\QueryExecuted;
-use Illuminate\Foundation\Http\Kernel;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Factory as ViewFactory;
@@ -68,6 +68,7 @@ final class ScoutApmServiceProvider extends ServiceProvider
         );
     }
 
+    /** @param \Illuminate\Foundation\Http\Kernel $kernel */
     public function boot(Kernel $kernel, ScoutApmAgent $agent, LoggerInterface $log, Connection $connection) : void
     {
         $agent->connect();
@@ -80,6 +81,8 @@ final class ScoutApmServiceProvider extends ServiceProvider
     /**
      * This installs all the instruments right here. If/when the laravel specific instruments grow, we should extract
      * them to a dedicated instrument manager as we add more.
+     *
+     * @param \Illuminate\Foundation\Http\Kernel $kernel
      */
     public function installInstruments(Kernel $kernel, ScoutApmAgent $agent, Connection $connection) : void
     {


### PR DESCRIPTION
So, methods such as `prependMiddleware` and `pushMiddleware` only exist on concrete implementation `Illuminate\Foundation\Http\Kernel`, and not on interface `Illuminate\Contracts\Http\Kernel`. This was flagged up by static analysis, so I'd flipped the `boot` to require the concrete rather than abstract. However, by doing so, Laravel instead magically instantiates a new, entirely separate `Kernel` implementation, rather than using the one already in the DI container. I've flipped back to depending on the interface (yay) and suppressed static analysis to tell it with `@param` that the concrete implementation is what gets passed. Just like the issue fixed in #9, (see https://github.com/scoutapp/scout-apm-laravel/blob/b1eb5219ef02d2c68d1dc94ce2d9062e2acf83e9/src/View/Engine/ScoutViewEngineDecorator.php#L48-L49)