### PR TITLE
Don't connect in Laravel boot()

### DIFF
--- a/src/Middleware/SendRequestToScout.php
+++ b/src/Middleware/SendRequestToScout.php
@@ -27,6 +27,8 @@ final class SendRequestToScout
 
     public function handle(Request $request, Closure $next) : Response
     {
+        $this->agent->connect();
+
         $response = $next($request);
 
         try {

--- a/src/Providers/ScoutApmServiceProvider.php
+++ b/src/Providers/ScoutApmServiceProvider.php
@@ -71,8 +71,6 @@ final class ScoutApmServiceProvider extends ServiceProvider
     /** @param \Illuminate\Foundation\Http\Kernel $kernel */
     public function boot(Kernel $kernel, ScoutApmAgent $agent, LoggerInterface $log, Connection $connection) : void
     {
-        $agent->connect();
-
         $log->debug('[Scout] Agent is starting');
 
         $this->installInstruments($kernel, $agent, $connection);


### PR DESCRIPTION
Move agent connect into SendRequestToScout middleware to avoid side-effects in Laravel boot()

Fixes #20 