### PR TITLE
Remove Response type restrictions on middlewares

### DIFF
--- a/src/Middleware/ActionInstrument.php
+++ b/src/Middleware/ActionInstrument.php
@@ -6,7 +6,6 @@ namespace Scoutapm\Laravel\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 use Psr\Log\LoggerInterface;
@@ -33,13 +32,13 @@ final class ActionInstrument
     }
 
     /** @throws Throwable */
-    public function handle(Request $request, Closure $next) : Response
+    public function handle(Request $request, Closure $next)
     {
         $this->logger->debug('[Scout] Handle ActionInstrument');
 
         return $this->agent->webTransaction(
             'unknown',
-            function (Span $span) use ($request, $next) : Response {
+            function (Span $span) use ($request, $next) {
                 $response = $next($request);
 
                 $span->updateName($this->automaticallyDetermineControllerName());

--- a/src/Middleware/IgnoredEndpoints.php
+++ b/src/Middleware/IgnoredEndpoints.php
@@ -6,7 +6,6 @@ namespace Scoutapm\Laravel\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Scoutapm\ScoutApmAgent;
 
 final class IgnoredEndpoints
@@ -19,7 +18,7 @@ final class IgnoredEndpoints
         $this->agent = $agent;
     }
 
-    public function handle(Request $request, Closure $next) : Response
+    public function handle(Request $request, Closure $next)
     {
         // Check if the request path we're handling is configured to be
         // ignored, and if so, mark it as such.

--- a/src/Middleware/MiddlewareInstrument.php
+++ b/src/Middleware/MiddlewareInstrument.php
@@ -6,7 +6,6 @@ namespace Scoutapm\Laravel\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Psr\Log\LoggerInterface;
 use Scoutapm\ScoutApmAgent;
 
@@ -24,14 +23,14 @@ final class MiddlewareInstrument
         $this->logger = $logger;
     }
 
-    public function handle(Request $request, Closure $next) : Response
+    public function handle(Request $request, Closure $next)
     {
         $this->logger->debug('[Scout] Handle MiddlewareInstrument');
 
         return $this->agent->instrument(
             'Middleware',
             'all',
-            static function () use ($request, $next) : Response {
+            static function () use ($request, $next) {
                 return $next($request);
             }
         );

--- a/src/Middleware/SendRequestToScout.php
+++ b/src/Middleware/SendRequestToScout.php
@@ -6,7 +6,6 @@ namespace Scoutapm\Laravel\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Psr\Log\LoggerInterface;
 use Scoutapm\ScoutApmAgent;
 use Throwable;
@@ -25,7 +24,7 @@ final class SendRequestToScout
         $this->logger = $logger;
     }
 
-    public function handle(Request $request, Closure $next) : Response
+    public function handle(Request $request, Closure $next)
     {
         $this->agent->connect();
 


### PR DESCRIPTION
the return type of the handle() method in a laravel Middleware should not be restricted to a Response object, it might also be ResponseJSON as seen on this error message that I got when testing this package:
`local.ERROR: Return value of Scoutapm\Laravel\Middleware\MiddlewareInstrument::Scoutapm\Laravel\Middleware\{closure}() must be an instance of Illuminate\Http\Response, instance of Illuminate\Http\JsonResponse returned
`

also note that the default laravel middleware stub is stating that the return type of the handle() function is mixed [https://github.com/laravel/framework/blob/c29c3c556fa3d0971421822f4980884640e74521/src/Illuminate/Routing/Console/stubs/middleware.stub#L14](https://github.com/laravel/framework/blob/c29c3c556fa3d0971421822f4980884640e74521/src/Illuminate/Routing/Console/stubs/middleware.stub#L14)