### PR TITLE
Fetch config from Laravel config repository so config can be cachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ A Scout account is required. [Signup for Scout](https://scoutapm.com/users/sign_
 ```bash
 composer require scoutapp/scout-apm-laravel
 ```
-    
+
+Then use Laravel's `artisan vendor:publish` to ensure configuration can be cached:
+
+```bash
+php artisan vendor:publish --provider="Scoutapm\Laravel\Providers\ScoutApmServiceProvider"
+```
+
 ### Configuration
 
 In your `.env` file, make sure you set a few configuration variables:

--- a/config/scout.php
+++ b/config/scout.php
@@ -11,7 +11,8 @@ declare(strict_types=1);
 
 use Scoutapm\Config\ConfigKey;
 
-return array_combine(
+/** @noinspection PhpUnnecessaryLocalVariableInspection */
+$config = array_combine(
     ConfigKey::allConfigurationKeys(),
     array_map(
         static function ($configKey) {
@@ -20,3 +21,11 @@ return array_combine(
         ConfigKey::allConfigurationKeys()
     )
 );
+
+/**
+ * If you want to override specific keys that were set in your env (or you don't want to use `.env` to configure), you
+ * can do so here; these will take precedence.
+ */
+// $config['key'] = 'actuallyThisOne';
+
+return $config;

--- a/config/scout.php
+++ b/config/scout.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * All of Scout configuration comes from `.env`.
+ *
+ * This `scout.php` file exists to automatically pull in all env vars into Laravel's configuration repository so that
+ * it can be cached, and accessed via the "dot" notation used in the config repository.
+ */
+
+use Scoutapm\Config\ConfigKey;
+
+return array_combine(
+    ConfigKey::allConfigurationKeys(),
+    array_map(
+        static function ($configKey) {
+            return env('SCOUT_' . strtoupper($configKey), null);
+        },
+        ConfigKey::allConfigurationKeys()
+    )
+);

--- a/src/Providers/ScoutApmServiceProvider.php
+++ b/src/Providers/ScoutApmServiceProvider.php
@@ -28,6 +28,10 @@ use Scoutapm\Laravel\View\Engine\ScoutViewEngineDecorator;
 use Scoutapm\Logger\FilteredLogLevelDecorator;
 use Scoutapm\ScoutApmAgent;
 use Throwable;
+use function array_combine;
+use function array_filter;
+use function array_map;
+use function config_path;
 
 final class ScoutApmServiceProvider extends ServiceProvider
 {
@@ -45,7 +49,8 @@ final class ScoutApmServiceProvider extends ServiceProvider
             return Config::fromArray(array_filter(array_combine(
                 ConfigKey::allConfigurationKeys(),
                 array_map(
-                    static function ($configurationKey) use ($configRepo) {
+                    /** @return mixed */
+                    static function (string $configurationKey) use ($configRepo) {
                         return $configRepo->get('scout.' . $configurationKey);
                     },
                     ConfigKey::allConfigurationKeys()
@@ -111,7 +116,7 @@ final class ScoutApmServiceProvider extends ServiceProvider
         $log->debug('Agent is starting');
 
         $this->publishes([
-            __DIR__ . '/../../config/scout.php' => config_path('scout.php')
+            __DIR__ . '/../../config/scout.php' => config_path('scout.php'),
         ]);
 
         $this->installInstruments($kernel, $agent, $connection);

--- a/tests/Unit/Providers/ScoutApmServiceProviderTest.php
+++ b/tests/Unit/Providers/ScoutApmServiceProviderTest.php
@@ -300,6 +300,13 @@ final class ScoutApmServiceProviderTest extends TestCase
             }
         );
 
+        $application->singleton(
+            'config',
+            static function () : ConfigRepository {
+                return new ConfigRepository();
+            }
+        );
+
         return $application;
     }
 }

--- a/tests/Unit/Providers/ScoutApmServiceProviderTest.php
+++ b/tests/Unit/Providers/ScoutApmServiceProviderTest.php
@@ -40,6 +40,7 @@ use Scoutapm\ScoutApmAgent;
 use Throwable;
 use function putenv;
 use function sprintf;
+use function sys_get_temp_dir;
 use function uniqid;
 
 /** @covers \Scoutapm\Laravel\Providers\ScoutApmServiceProvider */
@@ -333,6 +334,14 @@ final class ScoutApmServiceProviderTest extends TestCase
             'cache',
             static function () use ($application) : CacheManager {
                 return new CacheManager($application);
+            }
+        );
+
+        // Older versions of Laravel used `path.config` service name for path...
+        $application->singleton(
+            'path.config',
+            static function () : string {
+                return sys_get_temp_dir();
             }
         );
 


### PR DESCRIPTION
Adds a standard Laravel configuration structure to allow the config repository to be used (and therefore, allow Scout's configuration to be cacheable).

 * If a consumer does NOT use `config:cache` at the moment, they can continue to use `.env` and everything will work as-is, without any changes. They may optionally use the `vendor:publish` command to bring their configuration setup in line with the Laravel "standards"
 * If a consumer uses `config:cache`, the must use the `vendor:publish` command (as per added documentation in `README.md`) - this will fix behaviour observed in #33

Fixes #33 