### PR TITLE
Instrument laravel queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Pending [1.2.0]
 
+### Added
+
+ - Added support for Laravel Queues (#36)
+
 ### Changed
 
  - [BC] Renamed Scout APM's config file to `scout_apm.php` - if you use this, you will need to rename yours too (#38)

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/view": "^5.5.0|^6.0",
         "ramsey/uuid": "^3.0",
         "psr/log": "^1.0",
-        "scoutapp/scout-apm-php": "^2.1"
+        "scoutapp/scout-apm-php": "^2.1.1"
     },
     "require-dev": {
         "doctrine/coding-standard": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/view": "^5.5.0|^6.0",
         "ramsey/uuid": "^3.0",
         "psr/log": "^1.0",
-        "scoutapp/scout-apm-php": "^2.0"
+        "scoutapp/scout-apm-php": "^2.1"
     },
     "require-dev": {
         "doctrine/coding-standard": "^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7a12dab657170bd94d3a9eb18bb491b0",
+    "content-hash": "7b432908ecab644bfa8b1294d585a880",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -295,16 +295,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v6.6.1",
+            "version": "v6.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "0a8e3e6e96e5ec3af6b9f30026cb8e5551554875"
+                "reference": "ba4204f3a8b9672b6116398c165bd9c0c6eac077"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/0a8e3e6e96e5ec3af6b9f30026cb8e5551554875",
-                "reference": "0a8e3e6e96e5ec3af6b9f30026cb8e5551554875",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/ba4204f3a8b9672b6116398c165bd9c0c6eac077",
+                "reference": "ba4204f3a8b9672b6116398c165bd9c0c6eac077",
                 "shasum": ""
             },
             "require": {
@@ -400,7 +400,7 @@
                 "league/flysystem-sftp": "Required to use the Flysystem SFTP driver (^1.0).",
                 "moontoast/math": "Required to use ordered UUIDs (^1.1).",
                 "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
-                "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0)",
+                "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
                 "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0).",
                 "symfony/cache": "Required to PSR-6 cache bridge (^4.3.4).",
                 "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^1.2).",
@@ -437,20 +437,20 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2019-12-03T15:23:55+00:00"
+            "time": "2019-12-10T16:01:57+00:00"
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.57",
+            "version": "1.0.61",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "0e9db7f0b96b9f12dcf6f65bc34b72b1a30ea55a"
+                "reference": "4fb13c01784a6c9f165a351e996871488ca2d8c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/0e9db7f0b96b9f12dcf6f65bc34b72b1a30ea55a",
-                "reference": "0e9db7f0b96b9f12dcf6f65bc34b72b1a30ea55a",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/4fb13c01784a6c9f165a351e996871488ca2d8c9",
+                "reference": "4fb13c01784a6c9f165a351e996871488ca2d8c9",
                 "shasum": ""
             },
             "require": {
@@ -521,7 +521,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2019-10-16T21:01:05+00:00"
+            "time": "2019-12-08T21:46:50+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -833,28 +833,29 @@
         },
         {
             "name": "phpoption/phpoption",
-            "version": "1.6.0",
+            "version": "1.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/php-option.git",
-                "reference": "f4e7a6a1382183412246f0d361078c29fb85089e"
+                "reference": "77f7c4d2e65413aff5b5a8cc8b3caf7a28d81959"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/f4e7a6a1382183412246f0d361078c29fb85089e",
-                "reference": "f4e7a6a1382183412246f0d361078c29fb85089e",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/77f7c4d2e65413aff5b5a8cc8b3caf7a28d81959",
+                "reference": "77f7c4d2e65413aff5b5a8cc8b3caf7a28d81959",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.5.9 || ^7.0"
             },
             "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.3",
                 "phpunit/phpunit": "^4.8.35 || ^5.0 || ^6.0 || ^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6-dev"
+                    "dev-master": "1.7-dev"
                 }
             },
             "autoload": {
@@ -883,7 +884,7 @@
                 "php",
                 "type"
             ],
-            "time": "2019-11-30T20:20:49+00:00"
+            "time": "2019-12-15T19:35:24+00:00"
         },
         {
             "name": "psr/container",
@@ -1158,16 +1159,16 @@
         },
         {
             "name": "scoutapp/scout-apm-php",
-            "version": "2.0.0",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/scoutapp/scout-apm-php.git",
-                "reference": "72abf0c76b6e6287d89db2949c1058401965dae1"
+                "reference": "64e31cf86612ed83042d8330d4385d5dbddc0abe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scoutapp/scout-apm-php/zipball/72abf0c76b6e6287d89db2949c1058401965dae1",
-                "reference": "72abf0c76b6e6287d89db2949c1058401965dae1",
+                "url": "https://api.github.com/repos/scoutapp/scout-apm-php/zipball/64e31cf86612ed83042d8330d4385d5dbddc0abe",
+                "reference": "64e31cf86612ed83042d8330d4385d5dbddc0abe",
                 "shasum": ""
             },
             "require": {
@@ -1213,7 +1214,7 @@
                 "monitoring",
                 "performance"
             ],
-            "time": "2019-12-04T16:51:31+00:00"
+            "time": "2019-12-16T11:48:46+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -3637,16 +3638,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.9.3",
+            "version": "1.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea"
+                "reference": "579bb7356d91f9456ccd505f24ca8b667966a0a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/007c053ae6f31bba39dfa19a7726f56e9763bbea",
-                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/579bb7356d91f9456ccd505f24ca8b667966a0a7",
+                "reference": "579bb7356d91f9456ccd505f24ca8b667966a0a7",
                 "shasum": ""
             },
             "require": {
@@ -3681,7 +3682,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2019-08-09T12:45:53+00:00"
+            "time": "2019-12-15T19:12:40+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -4446,16 +4447,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.4.3",
+            "version": "8.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "67f9e35bffc0dd52d55d565ddbe4230454fd6a4e"
+                "reference": "3ee1c1fd6fc264480c25b6fb8285edefe1702dab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/67f9e35bffc0dd52d55d565ddbe4230454fd6a4e",
-                "reference": "67f9e35bffc0dd52d55d565ddbe4230454fd6a4e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3ee1c1fd6fc264480c25b6fb8285edefe1702dab",
+                "reference": "3ee1c1fd6fc264480c25b6fb8285edefe1702dab",
                 "shasum": ""
             },
             "require": {
@@ -4499,7 +4500,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "8.4-dev"
+                    "dev-master": "8.5-dev"
                 }
             },
             "autoload": {
@@ -4525,7 +4526,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-11-06T09:42:23+00:00"
+            "time": "2019-12-06T05:41:38+00:00"
         },
         {
             "name": "react/event-loop",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b432908ecab644bfa8b1294d585a880",
+    "content-hash": "6a48655b1799001eba914f64432f349f",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -295,16 +295,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v6.7.0",
+            "version": "v6.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "ba4204f3a8b9672b6116398c165bd9c0c6eac077"
+                "reference": "3d1d74bf11a72f030983f39e0f6b7ec55de952f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/ba4204f3a8b9672b6116398c165bd9c0c6eac077",
-                "reference": "ba4204f3a8b9672b6116398c165bd9c0c6eac077",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/3d1d74bf11a72f030983f39e0f6b7ec55de952f4",
+                "reference": "3d1d74bf11a72f030983f39e0f6b7ec55de952f4",
                 "shasum": ""
             },
             "require": {
@@ -437,7 +437,7 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2019-12-10T16:01:57+00:00"
+            "time": "2019-12-17T15:13:23+00:00"
         },
         {
             "name": "league/flysystem",
@@ -1072,22 +1072,22 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "3.9.1",
+            "version": "3.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "5ac2740e0c8c599d2bbe7f113a939f2b5b216c67"
+                "reference": "7779489a47d443f845271badbdcedfe4df8e06fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/5ac2740e0c8c599d2bbe7f113a939f2b5b216c67",
-                "reference": "5ac2740e0c8c599d2bbe7f113a939f2b5b216c67",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/7779489a47d443f845271badbdcedfe4df8e06fb",
+                "reference": "7779489a47d443f845271badbdcedfe4df8e06fb",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "paragonie/random_compat": "^1 | ^2 | 9.99.99",
-                "php": "^5.4 | ^7",
+                "php": "^5.4 | ^7 | ^8",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "replace": {
@@ -1097,13 +1097,13 @@
                 "codeception/aspect-mock": "^1 | ^2",
                 "doctrine/annotations": "^1.2",
                 "goaop/framework": "1.0.0-alpha.2 | ^1 | ^2.1",
-                "jakub-onderka/php-parallel-lint": "^0.9.0",
-                "mockery/mockery": "^0.9.9",
+                "jakub-onderka/php-parallel-lint": "^1",
+                "mockery/mockery": "^0.9.11 | ^1",
                 "moontoast/math": "^1.1",
                 "paragonie/random-lib": "^2",
                 "php-mock/php-mock-phpunit": "^0.3 | ^1.1",
                 "phpunit/phpunit": "^4.8 | ^5.4 | ^6.5",
-                "squizlabs/php_codesniffer": "^2.3"
+                "squizlabs/php_codesniffer": "^3.5"
             },
             "suggest": {
                 "ext-ctype": "Provides support for PHP Ctype functions",
@@ -1155,20 +1155,20 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2019-12-01T04:55:27+00:00"
+            "time": "2019-12-17T08:18:51+00:00"
         },
         {
             "name": "scoutapp/scout-apm-php",
-            "version": "v2.1.0",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/scoutapp/scout-apm-php.git",
-                "reference": "64e31cf86612ed83042d8330d4385d5dbddc0abe"
+                "reference": "bb7be17584d2eea3268ad7cb306f2eea034f8097"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scoutapp/scout-apm-php/zipball/64e31cf86612ed83042d8330d4385d5dbddc0abe",
-                "reference": "64e31cf86612ed83042d8330d4385d5dbddc0abe",
+                "url": "https://api.github.com/repos/scoutapp/scout-apm-php/zipball/bb7be17584d2eea3268ad7cb306f2eea034f8097",
+                "reference": "bb7be17584d2eea3268ad7cb306f2eea034f8097",
                 "shasum": ""
             },
             "require": {
@@ -1214,7 +1214,7 @@
                 "monitoring",
                 "performance"
             ],
-            "time": "2019-12-16T11:48:46+00:00"
+            "time": "2019-12-17T17:19:45+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -4085,33 +4085,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.9.0",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203"
+                "reference": "d638ebbb58daba25a6a0dc7969e1358a0e3c6682"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/f6811d96d97bdf400077a0cc100ae56aa32b9203",
-                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d638ebbb58daba25a6a0dc7969e1358a0e3c6682",
+                "reference": "d638ebbb58daba25a6a0dc7969e1358a0e3c6682",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.1|^2.0|^3.0",
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
+                "phpspec/phpspec": "^2.5 || ^3.2",
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev"
+                    "dev-master": "1.10.x-dev"
                 }
             },
             "autoload": {
@@ -4144,7 +4144,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2019-10-03T11:07:50+00:00"
+            "time": "2019-12-17T16:54:23+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -4622,12 +4622,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "e4ee2c8e4ccd908debc64069faf023c684a76760"
+                "reference": "1b2183eef1fdf7438d26b37dd87beb07dd4808bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/e4ee2c8e4ccd908debc64069faf023c684a76760",
-                "reference": "e4ee2c8e4ccd908debc64069faf023c684a76760",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/1b2183eef1fdf7438d26b37dd87beb07dd4808bc",
+                "reference": "1b2183eef1fdf7438d26b37dd87beb07dd4808bc",
                 "shasum": ""
             },
             "conflict": {
@@ -4648,7 +4648,7 @@
                 "composer/composer": "<=1-alpha.11",
                 "contao-components/mediaelement": ">=2.14.2,<2.21.1",
                 "contao/core": ">=2,<3.5.39",
-                "contao/core-bundle": ">=4,<4.4.39|>=4.5,<4.7.5",
+                "contao/core-bundle": ">=4,<4.4.46|>=4.5,<4.8.6",
                 "contao/listing-bundle": ">=4,<4.4.8",
                 "datadog/dd-trace": ">=0.30,<0.30.2",
                 "david-garcia/phpwhois": "<=4.3.1",
@@ -4695,7 +4695,7 @@
                 "league/commonmark": "<0.18.3",
                 "magento/magento1ce": "<1.9.4.3",
                 "magento/magento1ee": ">=1,<1.14.4.3",
-                "magento/product-community-edition": ">=2,<2.2.10|>=2.3,<2.3.2",
+                "magento/product-community-edition": ">=2,<2.2.10|>=2.3,<2.3.2-p.2",
                 "monolog/monolog": ">=1.8,<1.12",
                 "namshi/jose": "<2.2",
                 "onelogin/php-saml": "<2.10.4",
@@ -4777,8 +4777,8 @@
                 "titon/framework": ">=0,<9.9.99",
                 "truckersmp/phpwhois": "<=4.3.1",
                 "twig/twig": "<1.38|>=2,<2.7",
-                "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.27|>=9,<9.5.8",
-                "typo3/cms-core": ">=8,<8.7.27|>=9,<9.5.8",
+                "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.30|>=9,<9.5.12|>=10,<10.2.1",
+                "typo3/cms-core": ">=8,<8.7.30|>=9,<9.5.12|>=10,<10.2.1",
                 "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.10|>=3.1,<3.1.7|>=3.2,<3.2.7|>=3.3,<3.3.5",
                 "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4",
                 "typo3/phar-stream-wrapper": ">=1,<2.1.1|>=3,<3.1.1",
@@ -4832,7 +4832,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2019-12-02T13:03:15+00:00"
+            "time": "2019-12-17T15:12:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/src/Providers/ScoutApmServiceProvider.php
+++ b/src/Providers/ScoutApmServiceProvider.php
@@ -9,11 +9,12 @@ use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Contracts\Http\Kernel as HttpKernelInterface;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Foundation\Http\Kernel as HttpKernelImplementation;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Support\ServiceProvider;
@@ -22,12 +23,12 @@ use Illuminate\View\Factory as ViewFactory;
 use Scoutapm\Agent;
 use Scoutapm\Config;
 use Scoutapm\Config\ConfigKey;
-use Scoutapm\Events\Span\Span;
 use Scoutapm\Laravel\Database\QueryListener;
 use Scoutapm\Laravel\Middleware\ActionInstrument;
 use Scoutapm\Laravel\Middleware\IgnoredEndpoints;
 use Scoutapm\Laravel\Middleware\MiddlewareInstrument;
 use Scoutapm\Laravel\Middleware\SendRequestToScout;
+use Scoutapm\Laravel\Queue\JobQueueListener;
 use Scoutapm\Laravel\View\Engine\ScoutViewEngineDecorator;
 use Scoutapm\Logger\FilteredLogLevelDecorator;
 use Scoutapm\ScoutApmAgent;
@@ -114,25 +115,38 @@ final class ScoutApmServiceProvider extends ServiceProvider
         );
     }
 
-    /** @param \Illuminate\Foundation\Http\Kernel $kernel */
-    public function boot(Kernel $kernel, ScoutApmAgent $agent, FilteredLogLevelDecorator $log, Connection $connection) : void
-    {
+    /** @throws BindingResolutionException */
+    public function boot(
+        Application $application,
+        ScoutApmAgent $agent,
+        FilteredLogLevelDecorator $log,
+        Connection $connection
+    ) : void {
         $log->debug('Agent is starting');
 
         $this->publishes([
             __DIR__ . '/../../config/scout_apm.php' => config_path('scout_apm.php'),
         ]);
 
-        $this->instrumentMiddleware($kernel);
+        $runningInConsole = $application->runningInConsole();
+
         $this->instrumentDatabaseQueries($agent, $connection);
-        $this->instrumentQueues($agent, $kernel->getApplication()->make('events'));
+        $this->instrumentQueues($agent, $application->make('events'), $runningInConsole);
+
+        if ($runningInConsole) {
+            return;
+        }
+
+        $httpKernel = $application->make(HttpKernelInterface::class);
+        $this->instrumentMiddleware($httpKernel);
     }
 
     /**
+     * @param HttpKernelImplementation $kernel
+     *
      * @noinspection PhpDocSignatureInspection
-     * @param \Illuminate\Foundation\Http\Kernel $kernel
      */
-    private function instrumentMiddleware(Kernel $kernel) : void
+    private function instrumentMiddleware(HttpKernelInterface $kernel) : void
     {
         $kernel->prependMiddleware(MiddlewareInstrument::class);
         $kernel->pushMiddleware(ActionInstrument::class);
@@ -150,20 +164,22 @@ final class ScoutApmServiceProvider extends ServiceProvider
         });
     }
 
-    private function instrumentQueues(ScoutApmAgent $agent, Dispatcher $eventDispatcher)
+    private function instrumentQueues(ScoutApmAgent $agent, Dispatcher $eventDispatcher, bool $runningInConsole) : void
     {
-        $eventDispatcher->listen(JobProcessing::class, static function (JobProcessing $event) use ($agent) {
-            $agent->startSpan(Span::INSTRUMENT_JOB . '/' . class_basename($event->job->resolveName()));
+        $listener = new JobQueueListener($agent);
+
+        $eventDispatcher->listen(JobProcessing::class, static function (JobProcessing $event) use ($listener) : void {
+            $listener->startRequestForJob($event);
         });
 
-        $eventDispatcher->listen(JobProcessed::class, static function () use ($agent) {
-            $agent->stopSpan();
+        $eventDispatcher->listen(JobProcessed::class, static function (JobProcessed $event) use ($listener, $runningInConsole) : void {
+            $listener->stopSpanForJob();
 
-            /**
-             * @todo need to work out how to determine if we're "sync" or "async". If "sync" we can leave it to
-             * SendRequestToScout to send the request. If "async" we need to send it after each job.
-             */
-            $agent->send(); // @todo need to clear/reset the request each time we send...
+            if (! $runningInConsole) {
+                return;
+            }
+
+            $listener->sendRequestForJob();
         });
     }
 }

--- a/src/Providers/ScoutApmServiceProvider.php
+++ b/src/Providers/ScoutApmServiceProvider.php
@@ -7,18 +7,22 @@ namespace Scoutapm\Laravel\Providers;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Factory as ViewFactory;
 use Scoutapm\Agent;
 use Scoutapm\Config;
 use Scoutapm\Config\ConfigKey;
+use Scoutapm\Events\Span\Span;
 use Scoutapm\Laravel\Database\QueryListener;
 use Scoutapm\Laravel\Middleware\ActionInstrument;
 use Scoutapm\Laravel\Middleware\IgnoredEndpoints;
@@ -121,6 +125,7 @@ final class ScoutApmServiceProvider extends ServiceProvider
 
         $this->instrumentMiddleware($kernel);
         $this->instrumentDatabaseQueries($agent, $connection);
+        $this->instrumentQueues($agent, $kernel->getApplication()->make('events'));
     }
 
     /**
@@ -142,6 +147,23 @@ final class ScoutApmServiceProvider extends ServiceProvider
     {
         $connection->listen(static function (QueryExecuted $query) use ($agent) : void {
             (new QueryListener($agent))->__invoke($query);
+        });
+    }
+
+    private function instrumentQueues(ScoutApmAgent $agent, Dispatcher $eventDispatcher)
+    {
+        $eventDispatcher->listen(JobProcessing::class, static function (JobProcessing $event) use ($agent) {
+            $agent->startSpan(Span::INSTRUMENT_JOB . '/' . class_basename($event->job->resolveName()));
+        });
+
+        $eventDispatcher->listen(JobProcessed::class, static function () use ($agent) {
+            $agent->stopSpan();
+
+            /**
+             * @todo need to work out how to determine if we're "sync" or "async". If "sync" we can leave it to
+             * SendRequestToScout to send the request. If "async" we need to send it after each job.
+             */
+            $agent->send(); // @todo need to clear/reset the request each time we send...
         });
     }
 }

--- a/src/Queue/JobQueueListener.php
+++ b/src/Queue/JobQueueListener.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\Laravel\Queue;
+
+use Exception;
+use Illuminate\Queue\Events\JobProcessing;
+use Scoutapm\Events\Span\Span;
+use Scoutapm\ScoutApmAgent;
+use function class_basename;
+use function sprintf;
+
+final class JobQueueListener
+{
+    /** @var ScoutApmAgent */
+    private $agent;
+
+    public function __construct(ScoutApmAgent $agent)
+    {
+        $this->agent = $agent;
+    }
+
+    /** @throws Exception */
+    public function startRequestForJob(JobProcessing $jobProcessingEvent) : void
+    {
+        /** @noinspection UnusedFunctionResultInspection */
+        $this->agent->startSpan(sprintf(
+            '%s/%s',
+            Span::INSTRUMENT_JOB,
+            class_basename($jobProcessingEvent->job->resolveName())
+        ));
+    }
+
+    /** @throws Exception */
+    public function stopSpanForJob() : void
+    {
+        $this->agent->stopSpan();
+    }
+
+    /** @throws Exception */
+    public function sendRequestForJob() : void
+    {
+        $this->agent->send();
+    }
+}

--- a/src/Queue/JobQueueListener.php
+++ b/src/Queue/JobQueueListener.php
@@ -41,6 +41,7 @@ final class JobQueueListener
     /** @throws Exception */
     public function sendRequestForJob() : void
     {
+        $this->agent->connect();
         $this->agent->send();
     }
 }

--- a/tests/Unit/Providers/ScoutApmServiceProviderTest.php
+++ b/tests/Unit/Providers/ScoutApmServiceProviderTest.php
@@ -285,7 +285,7 @@ final class ScoutApmServiceProviderTest extends TestCase
      * Helper to create a Laravel application instance that has very basic wiring up of services that our Laravel
      * binding library actually interacts with in some way.
      */
-    private function createLaravelApplicationFulfillingBasicRequirementsForScout($runningInConsole = false) : Application
+    private function createLaravelApplicationFulfillingBasicRequirementsForScout(bool $runningInConsole = false) : Application
     {
         $application = $this->getMockBuilder(Application::class)
             ->setMethods(['runningInConsole'])

--- a/tests/Unit/Queue/JobQueueListenerTest.php
+++ b/tests/Unit/Queue/JobQueueListenerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scoutapm\Laravel\UnitTests\Queue;
+
+use Exception;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\Events\JobProcessing;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Scoutapm\Laravel\Queue\JobQueueListener;
+use Scoutapm\ScoutApmAgent;
+
+/** @covers \Scoutapm\Laravel\Queue\JobQueueListener */
+final class JobQueueListenerTest extends TestCase
+{
+    /** @var ScoutApmAgent&MockObject */
+    private $agent;
+    /** @var JobQueueListener */
+    private $jobQueueListener;
+
+    public function setUp() : void
+    {
+        parent::setUp();
+        $this->agent = $this->createMock(ScoutApmAgent::class);
+
+        $this->jobQueueListener = new JobQueueListener($this->agent);
+    }
+
+    /** @throws Exception */
+    public function testSpanIsStarted() : void
+    {
+        $this->agent->expects(self::once())
+            ->method('startSpan')
+            ->with('Job/Foo');
+
+        $job = $this->createMock(Job::class);
+        $job->expects(self::once())
+            ->method('resolveName')
+            ->willReturn('Foo');
+
+        $event = new JobProcessing('connection', $job);
+
+        $this->jobQueueListener->startRequestForJob($event);
+    }
+
+    /** @throws Exception */
+    public function testSpanIsStopped() : void
+    {
+        $this->agent->expects(self::once())
+            ->method('stopSpan');
+
+        $this->jobQueueListener->stopSpanForJob();
+    }
+
+    /** @throws Exception */
+    public function testRequestIsSentAndReset() : void
+    {
+        $this->agent->expects(self::once())
+            ->method('send');
+
+        $this->jobQueueListener->sendRequestForJob();
+
+        self::markTestIncomplete('Need to figure a way to ensure request has been reset');
+    }
+}

--- a/tests/Unit/Queue/JobQueueListenerTest.php
+++ b/tests/Unit/Queue/JobQueueListenerTest.php
@@ -55,8 +55,11 @@ final class JobQueueListenerTest extends TestCase
     }
 
     /** @throws Exception */
-    public function testRequestIsSentAndReset() : void
+    public function testAgentConnectsAndSendsWhenRequestIsToBeSent() : void
     {
+        $this->agent->expects(self::once())
+            ->method('connect');
+
         $this->agent->expects(self::once())
             ->method('send');
 

--- a/tests/Unit/Queue/JobQueueListenerTest.php
+++ b/tests/Unit/Queue/JobQueueListenerTest.php
@@ -61,7 +61,5 @@ final class JobQueueListenerTest extends TestCase
             ->method('send');
 
         $this->jobQueueListener->sendRequestForJob();
-
-        self::markTestIncomplete('Need to figure a way to ensure request has been reset');
     }
 }


### PR DESCRIPTION
Fixes #35 

 - [x] Detect if we're running sync/async
   - sync does not need to call `send()` since `SendRequestToScout` middleware will
   - async will need to call `send()` after each job is processed (since a single worker is a single long-running thread)
 - [x] Figure a clean way to "reset" the request after each job is processed (in "async" mode)
 - [x] Find a way to fake `runningInConsole()` on older Laravel versions
 - [x] Pin to a new release of `scout-apm-php`
 - [x] Changelog update (1.2.0 since new feature)