### PR TITLE
Allow for Ramsey UUID V4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "illuminate/routing": "^5.5.0|^6.0|^7.0",
         "illuminate/support": "^5.5.0|^6.0|^7.0",
         "illuminate/view": "^5.5.0|^6.0|^7.0",
-        "ramsey/uuid": "^3.0",
+        "ramsey/uuid": "^3.0|^4.0",
         "psr/log": "^1.0",
         "scoutapp/scout-apm-php": "^4.2"
     },


### PR DESCRIPTION
This patch allows for projects using latest version on Laravel to install without a problem.

Fixes #55